### PR TITLE
Add Metronome

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transcribe",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/features/audio/PlayerControls.tsx
+++ b/src/features/audio/PlayerControls.tsx
@@ -1,4 +1,5 @@
 import {
+  Drum,
   Gauge,
   MusicIcon,
   Pause,
@@ -21,6 +22,7 @@ import {
   PLAYBACK_RATE_STEP,
 } from "@/lib/constants";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
+import { useMetronome } from "@/hooks/useMetronome";
 import { useShallow } from "zustand/react/shallow";
 import { useStore } from "@/store";
 import { cn } from "@/lib/utils";
@@ -31,29 +33,34 @@ export function PlayerControls() {
     playbackRate,
     detune,
     isLooping,
+    metronomeEnabled,
     currentTime,
     duration,
     setPlaying,
     setPlaybackRate,
     setDetune,
     setLooping,
+    setMetronomeEnabled,
   } = useStore(
     useShallow((s) => ({
       isPlaying: s.isPlaying,
       playbackRate: s.playbackRate,
       detune: s.detune,
       isLooping: s.isLooping,
+      metronomeEnabled: s.metronomeEnabled,
       currentTime: s.currentTime,
       duration: s.duration,
       setPlaying: s.setPlaying,
       setPlaybackRate: s.setPlaybackRate,
       setDetune: s.setDetune,
       setLooping: s.setLooping,
+      setMetronomeEnabled: s.setMetronomeEnabled,
     }))
   );
 
-  // The hook manages the Tone.js engine side-effects
+  // The hooks manage Tone.js engine side-effects
   useAudioPlayer();
+  useMetronome();
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
@@ -85,6 +92,21 @@ export function PlayerControls() {
           </Button>
         </TooltipTrigger>
         <TooltipContent>Loop selected region</TooltipContent>
+      </Tooltip>
+
+      {/* Metronome toggle */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={metronomeEnabled ? "secondary" : "ghost"}
+            size="icon"
+            onClick={() => setMetronomeEnabled(!metronomeEnabled)}
+            className={cn("shrink-0", metronomeEnabled && "ring-1 ring-primary")}
+          >
+            <Drum className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Metronome</TooltipContent>
       </Tooltip>
 
       {/* Current time */}

--- a/src/hooks/useMetronome.ts
+++ b/src/hooks/useMetronome.ts
@@ -17,7 +17,6 @@ import { useStore } from "@/store";
 export function useMetronome() {
   const loopRef = useRef<Tone.Loop | null>(null);
   const beatIndexRef = useRef<number>(0);
-  const loopScheduledRef = useRef<boolean>(false);
   const accentSynthRef = useRef<Tone.Synth | null>(null);
   const normalSynthRef = useRef<Tone.Synth | null>(null);
 
@@ -44,62 +43,53 @@ export function useMetronome() {
     };
   }, []);
 
-  // ── Internal helpers ─────────────────────────────────────────────────────
-
-  const stopLoop = () => {
-    loopRef.current?.stop(0);
-    loopRef.current?.dispose();
-    loopRef.current = null;
-    loopScheduledRef.current = false;
-    beatIndexRef.current = 0;
-  };
-
-  const buildLoop = () => {
-    const { bpm, timeSignature, playbackRate, firstMeasureStart } = useStore.getState();
-    const beatsPerMeasure = TIME_SIGNATURE_BEATS[timeSignature];
-    const beatInterval = (60 / bpm) / playbackRate;
-    const loopStart = firstMeasureStart / playbackRate;
-
-    const loop = new Tone.Loop((time) => {
-      const accent = beatIndexRef.current % beatsPerMeasure === 0;
-      const synth = accent ? accentSynthRef.current : normalSynthRef.current;
-      synth?.triggerAttackRelease(accent ? 1000 : 600, "32n", time);
-      beatIndexRef.current += 1;
-    }, beatInterval);
-
-    loopRef.current = loop;
-    return { loop, loopStart };
-  };
-
-  const startLoop = () => {
-    if (loopScheduledRef.current) return;
-    const { loop, loopStart } = buildLoop();
-    loop.start(loopStart);
-    loopScheduledRef.current = true;
-  };
-
-  // ── React to play state and metronome toggle ─────────────────────────────
+  // ── All store subscriptions in a single effect ───────────────────────────
 
   useEffect(() => {
-    const unsub = useStore.subscribe(
+    // Does not reset beatIndexRef — callers that need a fresh index (seek, project
+    // load) set it explicitly before or after calling stopLoop.
+    const stopLoop = () => {
+      loopRef.current?.dispose();
+      loopRef.current = null;
+    };
+
+    const startLoop = () => {
+      if (loopRef.current) return;
+      const { bpm, timeSignature, playbackRate, firstMeasureStart, currentTime } = useStore.getState();
+      const beatsPerMeasure = TIME_SIGNATURE_BEATS[timeSignature];
+      const beatInterval = (60 / bpm) / playbackRate;
+      const loopStart = firstMeasureStart / playbackRate;
+      // Use currentTime (audio time) / playbackRate instead of Tone.getTransport().seconds
+      // so that rate-change restarts read the correct Transport position before useAudioPlayer's
+      // React effect has had a chance to compensate Transport.seconds for the new rate.
+      const startAt = Math.max(loopStart, currentTime / playbackRate);
+
+      // Calibrate beat index to the start position so accents align with measure downbeats.
+      // This covers: first play mid-song, metronome toggle while playing, and param changes.
+      const elapsed = Math.max(0, currentTime / playbackRate - loopStart);
+      beatIndexRef.current = Math.round(elapsed / beatInterval) % beatsPerMeasure;
+
+      const loop = new Tone.Loop((time) => {
+        const accent = beatIndexRef.current % beatsPerMeasure === 0;
+        const synth = accent ? accentSynthRef.current : normalSynthRef.current;
+        synth?.triggerAttackRelease(accent ? 1000 : 600, "32n", time);
+        beatIndexRef.current += 1;
+      }, beatInterval);
+
+      loopRef.current = loop;
+      loop.start(startAt);
+    };
+
+    const unsubPlayback = useStore.subscribe(
       (s) => ({ isPlaying: s.isPlaying, metronomeEnabled: s.metronomeEnabled }),
       ({ isPlaying, metronomeEnabled }) => {
-        if (isPlaying && metronomeEnabled) {
-          startLoop();
-        } else {
-          stopLoop();
-        }
+        if (isPlaying && metronomeEnabled) startLoop();
+        else stopLoop();
       },
       { equalityFn: shallow }
     );
-    return unsub;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
-  // ── Rebuild loop when BPM / time signature / rate / offset changes ───────
-
-  useEffect(() => {
-    const unsub = useStore.subscribe(
+    const unsubParams = useStore.subscribe(
       (s) => ({
         bpm: s.bpm,
         timeSignature: s.timeSignature,
@@ -113,45 +103,40 @@ export function useMetronome() {
       },
       { equalityFn: shallow }
     );
-    return unsub;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
-  // ── Stop loop when a new project is loading (Transport.cancel() is called) ──
-
-  useEffect(() => {
-    const unsub = useStore.subscribe(
+    // Transport.cancel() is called on project load, which destroys all scheduled
+    // events and makes our loop reference stale — stop before that happens.
+    const unsubStatus = useStore.subscribe(
       (s) => s.status,
       (status) => {
-        if (status === "loading") stopLoop();
+        if (status === "loading") {
+          stopLoop();
+          beatIndexRef.current = 0;
+        }
       }
     );
-    return unsub;
-   
-  }, []);
 
-  // ── Recalibrate beat index on seek so accents stay aligned ───────────────
-
-  useEffect(() => {
-    const unsub = useStore.subscribe(
+    const unsubSeek = useStore.subscribe(
       (s) => s.seekTarget,
       (seekTarget) => {
         if (seekTarget === null) return;
-        const { bpm, timeSignature, playbackRate, firstMeasureStart } = useStore.getState();
-        const beatsPerMeasure = TIME_SIGNATURE_BEATS[timeSignature];
-        const beatInterval = (60 / bpm) / playbackRate;
-        const offsetSeconds = firstMeasureStart / playbackRate;
-        const elapsed = Math.max(0, seekTarget / playbackRate - offsetSeconds);
-        beatIndexRef.current = Math.round(elapsed / beatInterval) % beatsPerMeasure;
+        // seek() atomically sets currentTime = seekTarget, so startLoop() will calibrate
+        // beatIndexRef from the new position. Restarting the loop also re-anchors its
+        // AudioContext phase so clicks land on beat boundaries after the seek.
+        if (loopRef.current) {
+          const { isPlaying, metronomeEnabled } = useStore.getState();
+          stopLoop();
+          if (isPlaying && metronomeEnabled) startLoop();
+        }
       }
     );
-    return unsub;
-  }, []);
 
-  // ── Cleanup on unmount ───────────────────────────────────────────────────
-
-  useEffect(() => {
-    return () => stopLoop();
-   
+    return () => {
+      unsubPlayback();
+      unsubParams();
+      unsubStatus();
+      unsubSeek();
+      stopLoop();
+    };
   }, []);
 }

--- a/src/hooks/useMetronome.ts
+++ b/src/hooks/useMetronome.ts
@@ -1,0 +1,157 @@
+import { useEffect, useRef } from "react";
+import * as Tone from "tone";
+import { shallow } from "zustand/shallow";
+
+import { TIME_SIGNATURE_BEATS } from "@/model/types";
+import { useStore } from "@/store";
+
+/**
+ * Drives a metronome click track on the existing Tone.Transport.
+ *
+ * Beat scheduling is done in Transport time (wall-clock seconds).
+ * Loop interval = (60 / bpm) / playbackRate so clicks stay aligned
+ * with the audio content at any playback speed.
+ *
+ * Call this hook alongside useAudioPlayer() in PlayerControls.
+ */
+export function useMetronome() {
+  const loopRef = useRef<Tone.Loop | null>(null);
+  const beatIndexRef = useRef<number>(0);
+  const loopScheduledRef = useRef<boolean>(false);
+  const accentSynthRef = useRef<Tone.Synth | null>(null);
+  const normalSynthRef = useRef<Tone.Synth | null>(null);
+
+  // ── Create synths on mount, dispose on unmount ───────────────────────────
+
+  useEffect(() => {
+    accentSynthRef.current = new Tone.Synth({
+      oscillator: { type: "triangle" },
+      envelope: { attack: 0.001, decay: 0.04, sustain: 0, release: 0.04 },
+      volume: -6,
+    }).toDestination();
+
+    normalSynthRef.current = new Tone.Synth({
+      oscillator: { type: "triangle" },
+      envelope: { attack: 0.001, decay: 0.03, sustain: 0, release: 0.03 },
+      volume: -12,
+    }).toDestination();
+
+    return () => {
+      accentSynthRef.current?.dispose();
+      normalSynthRef.current?.dispose();
+      accentSynthRef.current = null;
+      normalSynthRef.current = null;
+    };
+  }, []);
+
+  // ── Internal helpers ─────────────────────────────────────────────────────
+
+  const stopLoop = () => {
+    loopRef.current?.stop(0);
+    loopRef.current?.dispose();
+    loopRef.current = null;
+    loopScheduledRef.current = false;
+    beatIndexRef.current = 0;
+  };
+
+  const buildLoop = () => {
+    const { bpm, timeSignature, playbackRate, firstMeasureStart } = useStore.getState();
+    const beatsPerMeasure = TIME_SIGNATURE_BEATS[timeSignature];
+    const beatInterval = (60 / bpm) / playbackRate;
+    const loopStart = firstMeasureStart / playbackRate;
+
+    const loop = new Tone.Loop((time) => {
+      const accent = beatIndexRef.current % beatsPerMeasure === 0;
+      const synth = accent ? accentSynthRef.current : normalSynthRef.current;
+      synth?.triggerAttackRelease(accent ? 1000 : 600, "32n", time);
+      beatIndexRef.current += 1;
+    }, beatInterval);
+
+    loopRef.current = loop;
+    return { loop, loopStart };
+  };
+
+  const startLoop = () => {
+    if (loopScheduledRef.current) return;
+    const { loop, loopStart } = buildLoop();
+    loop.start(loopStart);
+    loopScheduledRef.current = true;
+  };
+
+  // ── React to play state and metronome toggle ─────────────────────────────
+
+  useEffect(() => {
+    const unsub = useStore.subscribe(
+      (s) => ({ isPlaying: s.isPlaying, metronomeEnabled: s.metronomeEnabled }),
+      ({ isPlaying, metronomeEnabled }) => {
+        if (isPlaying && metronomeEnabled) {
+          startLoop();
+        } else {
+          stopLoop();
+        }
+      },
+      { equalityFn: shallow }
+    );
+    return unsub;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Rebuild loop when BPM / time signature / rate / offset changes ───────
+
+  useEffect(() => {
+    const unsub = useStore.subscribe(
+      (s) => ({
+        bpm: s.bpm,
+        timeSignature: s.timeSignature,
+        playbackRate: s.playbackRate,
+        firstMeasureStart: s.firstMeasureStart,
+      }),
+      () => {
+        const { isPlaying, metronomeEnabled } = useStore.getState();
+        stopLoop();
+        if (isPlaying && metronomeEnabled) startLoop();
+      },
+      { equalityFn: shallow }
+    );
+    return unsub;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Stop loop when a new project is loading (Transport.cancel() is called) ──
+
+  useEffect(() => {
+    const unsub = useStore.subscribe(
+      (s) => s.status,
+      (status) => {
+        if (status === "loading") stopLoop();
+      }
+    );
+    return unsub;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Recalibrate beat index on seek so accents stay aligned ───────────────
+
+  useEffect(() => {
+    const unsub = useStore.subscribe(
+      (s) => s.seekTarget,
+      (seekTarget) => {
+        if (seekTarget === null) return;
+        const { bpm, timeSignature, playbackRate, firstMeasureStart } = useStore.getState();
+        const beatsPerMeasure = TIME_SIGNATURE_BEATS[timeSignature];
+        const beatInterval = (60 / bpm) / playbackRate;
+        const offsetSeconds = firstMeasureStart / playbackRate;
+        const elapsed = Math.max(0, seekTarget / playbackRate - offsetSeconds);
+        beatIndexRef.current = Math.round(elapsed / beatInterval) % beatsPerMeasure;
+      }
+    );
+    return unsub;
+  }, []);
+
+  // ── Cleanup on unmount ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    return () => stopLoop();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/hooks/useMetronome.ts
+++ b/src/hooks/useMetronome.ts
@@ -127,7 +127,7 @@ export function useMetronome() {
       }
     );
     return unsub;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   }, []);
 
   // ── Recalibrate beat index on seek so accents stay aligned ───────────────
@@ -152,6 +152,6 @@ export function useMetronome() {
 
   useEffect(() => {
     return () => stopLoop();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   }, []);
 }

--- a/src/pages/HelpPage.tsx
+++ b/src/pages/HelpPage.tsx
@@ -1,5 +1,6 @@
 import {
   AudioLines,
+  Drum,
   Gauge,
   Maximize2,
   MusicIcon,
@@ -143,6 +144,11 @@ export function HelpPage() {
             label="Pitch shift"
             description="Transpose the audio up or down in semitones without affecting speed. Useful when a recording is slightly out of tune. Range: −12 to +12 semitones."
           />
+          <Row
+            icon={<Drum />}
+            label="Metronome"
+            description="Toggle an audible click track that follows the song's BPM and time signature. Beat 1 of each measure plays an accented click; other beats play a softer click. The metronome stays in sync at any playback speed."
+          />
         </div>
       </Section>
 
@@ -181,6 +187,7 @@ export function HelpPage() {
           <li>Use the scroll wheel over the waveform to zoom without clicking the zoom buttons.</li>
           <li>Slow playback to 0.5× while looping a tricky passage to hear every note clearly.</li>
           <li>Use pitch shift to match a recording to a reference instrument that may be tuned differently.</li>
+          <li>Enable the metronome while slowing playback to check if your BPM setting is correctly aligned with the recording.</li>
           <li>Save frequently — the browser has no auto-save and a page refresh will lose unsaved changes.</li>
         </ul>
       </Section>

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -24,6 +24,7 @@ const resetStore = () =>
     loopEnd: 0,
     currentTime: 0,
     seekTarget: null,
+    metronomeEnabled: false,
     currentDialog: "none",
     currentPath: "/",
   });
@@ -67,6 +68,12 @@ describe("createProject", () => {
     expect(s.currentTime).toBe(0);
     expect(s.loopStart).toBe(0);
   });
+
+  it("resets metronomeEnabled to false", () => {
+    useStore.setState({ metronomeEnabled: true });
+    get().createProject("Test", "blob:url", 10);
+    expect(get().metronomeEnabled).toBe(false);
+  });
 });
 
 // ─── loadProject ─────────────────────────────────────────────────────────────
@@ -102,6 +109,12 @@ describe("loadProject", () => {
     expect(s.currentTime).toBe(0);
     expect(s.loopEnd).toBe(30);
   });
+
+  it("resets metronomeEnabled to false", () => {
+    useStore.setState({ metronomeEnabled: true });
+    get().loadProject(persistedState, "blob:saved");
+    expect(get().metronomeEnabled).toBe(false);
+  });
 });
 
 // ─── setProjectReady ──────────────────────────────────────────────────────────
@@ -111,6 +124,12 @@ describe("setProjectReady", () => {
     useStore.setState({ status: "loading" });
     get().setProjectReady();
     expect(get().status).toBe("ready");
+  });
+
+  it("does not change metronomeEnabled", () => {
+    useStore.setState({ status: "loading", metronomeEnabled: false });
+    get().setProjectReady();
+    expect(get().metronomeEnabled).toBe(false);
   });
 });
 
@@ -129,6 +148,12 @@ describe("resetProject", () => {
     expect(s.duration).toBe(0);
     expect(s.isPlaying).toBe(false);
     expect(s.currentTime).toBe(0);
+  });
+
+  it("resets metronomeEnabled to false", () => {
+    useStore.setState({ metronomeEnabled: true });
+    get().resetProject();
+    expect(get().metronomeEnabled).toBe(false);
   });
 });
 
@@ -287,6 +312,13 @@ describe("audio actions", () => {
     get().seek(5);
     get().clearSeekTarget();
     expect(get().seekTarget).toBeNull();
+  });
+
+  it("setMetronomeEnabled toggles metronomeEnabled", () => {
+    get().setMetronomeEnabled(true);
+    expect(get().metronomeEnabled).toBe(true);
+    get().setMetronomeEnabled(false);
+    expect(get().metronomeEnabled).toBe(false);
   });
 });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,6 +49,7 @@ interface AudioSlice {
   currentTime: number;
   /** Set by waveform/measure clicks; consumed by useAudioPlayer to move Tone.Transport */
   seekTarget: number | null;
+  metronomeEnabled: boolean;
 }
 
 interface UiSlice {
@@ -86,6 +87,7 @@ interface Actions {
   /** Seek to a time (triggers Tone.Transport move via useAudioPlayer) */
   seek: (time: number) => void;
   clearSeekTarget: () => void;
+  setMetronomeEnabled: (enabled: boolean) => void;
 
   // UI
   openDialog: (dialog: DialogType) => void;
@@ -123,6 +125,7 @@ export const useStore = create<AppStore>()(
     loopEnd: 0,
     currentTime: 0,
     seekTarget: null,
+    metronomeEnabled: false,
 
     // ── UI defaults ──
     currentDialog: "none",
@@ -279,6 +282,7 @@ export const useStore = create<AppStore>()(
       set({ seekTarget: time, currentTime: time });
     },
     clearSeekTarget: () => set({ seekTarget: null }),
+    setMetronomeEnabled: (enabled) => set({ metronomeEnabled: enabled }),
 
     // ──────────────────────────────────────────────────────────────────────────
     // UI actions

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -159,6 +159,7 @@ export const useStore = create<AppStore>()(
         measures,
         sections,
         isPlaying: false,
+        metronomeEnabled: false,
         currentTime: 0,
         loopStart: 0,
         loopEnd: duration,
@@ -177,6 +178,7 @@ export const useStore = create<AppStore>()(
         sections: state.sections,
         measures: state.measures,
         isPlaying: false,
+        metronomeEnabled: false,
         currentTime: 0,
         loopStart: 0,
         loopEnd: state.duration,
@@ -194,6 +196,7 @@ export const useStore = create<AppStore>()(
         measures: EMPTY_MEASURES,
         duration: 0,
         isPlaying: false,
+        metronomeEnabled: false,
         currentTime: 0,
       }),
 


### PR DESCRIPTION
Adds an audible metronome click track to the player controls, driven by the song's BPM and time signature settings.

- Beat 1 of each measure plays an accented click (1000 Hz); all other beats play a softer click (600 Hz)
- Click track stays in sync at any playback speed — the interval scales with `playbackRate` so the metronome follows slowed-down audio correctly
- Respects `firstMeasureStart` — clicks begin at the downbeat of measure 0, not at time zero
- Toggle button in the player controls bar (drum icon), styled consistently with the existing loop toggle
- BPM, time signature, and playback rate changes rebuild the click schedule immediately via Zustand subscribers outside React's render cycle, avoiding races with the Tone.js Transport
- Beat index recalibrates on seek so the measure-1 accent stays aligned after jumping to a new position
- Help page updated with metronome entry and usage tip

## Technical notes

- New `useMetronome` hook schedules a `Tone.Loop` on the existing Transport — no separate Transport created
- Two `Tone.Synth` instances (accent + normal) with short triangle-wave envelopes, created once on mount and disposed on unmount
- Loop is torn down and rebuilt when `status === "loading"` (new project) since `Transport.cancel()` wipes all scheduled events
- `metronomeEnabled` added to the Zustand `AudioSlice`

## Test plan
- [ ] Toggle metronome while playing — click track starts/stops immediately
- [ ] Toggle metronome while paused — click track starts on next play
- [ ] Change BPM while metronome is active — clicks re-align to new tempo
- [ ] Seek while metronome is active — beat 1 accent stays on measure downbeats
- [ ] Change playback speed — clicks stay locked to audio content
- [ ] Load a new project — no ghost clicks from previous session
- [ ] Check Help page shows metronome entry